### PR TITLE
FIX: collections useless re-renders (+ missing setKeys method in type)

### DIFF
--- a/packages/formiz-core/src/store.ts
+++ b/packages/formiz-core/src/store.ts
@@ -703,17 +703,13 @@ export const createStore = <Values extends object = DefaultFormValues>(
           get().collections.set(
             fieldName.toString(),
             typeof keys === "function"
-              ? keys(get().actions.getCollectionKeys(fieldName) ?? [])
+              ? keys(get().collections.get(fieldName) ?? [])
               : keys
           );
           return {
             collections: state.collections,
           };
         });
-      },
-
-      getCollectionKeys: (fieldName) => {
-        return get().collections.get(fieldName.toString());
       },
 
       setCollectionValues: (fieldName) => (values, options) => {

--- a/packages/formiz-core/src/types.ts
+++ b/packages/formiz-core/src/types.ts
@@ -392,7 +392,6 @@ export interface Store<Values extends object = DefaultFormValues> {
     ): (
       keys: CollectionKey[] | ((oldKeys: CollectionKey[]) => CollectionKey[])
     ) => void;
-    getCollectionKeys(fieldName: string): CollectionKey[] | undefined;
     setCollectionValues(
       fieldName: string
     ): (

--- a/packages/formiz-core/src/useCollection.ts
+++ b/packages/formiz-core/src/useCollection.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useMemo } from "react";
 import lodashGet from "lodash/get";
 import { StoreApi, UseBoundStore } from "zustand";
-import { Store } from "./types";
+import { CollectionKey, Store } from "./types";
 import { useFormStore } from "./Formiz";
 import { deepEqual } from "fast-equals";
 
@@ -13,7 +13,7 @@ export interface UseCollectionOptions {
 }
 
 export type UseCollectionValues<Data = unknown> = {
-  keys: string[];
+  keys: CollectionKey[];
   insertMultiple(
     index: number,
     data?: Partial<Data>[],
@@ -37,6 +37,9 @@ export type UseCollectionValues<Data = unknown> = {
   set(
     values: unknown[],
     options?: Parameters<Store["actions"]["setValues"]>[1]
+  ): void;
+  setKeys(
+    keys: CollectionKey[] | ((oldKeys: CollectionKey[]) => CollectionKey[])
   ): void;
   length: number;
 };
@@ -87,14 +90,14 @@ export const useCollection = <Data = unknown>(
     return {
       isReady: state.ready,
       keys: state.ready
-        ? state.actions.getCollectionKeys(name) ??
+        ? state.collections.get(name) ??
           initialValuesArray.map((_, index) => index.toString())
         : [],
       hasInitialValues: Array.isArray(initialValues)
         ? !!initialValues?.length
         : false,
     };
-  });
+  }, deepEqual);
 
   const collectionActions = useMemo(
     () => ({


### PR DESCRIPTION
Fix an issue where useCollection causes useless re-renders
+ fix missing setKeys method in collection actions returned by useCollection