### PR TITLE
Fix: useForm doesn't return up to date id

### DIFF
--- a/packages/formiz-core/src/store.ts
+++ b/packages/formiz-core/src/store.ts
@@ -60,9 +60,12 @@ export const createStore = <Values extends object = DefaultFormValues>(
     actions: {
       // FORM
       updateConfig: (formConfigRef) => {
-        const wasReady = get().ready;
-        set(() => ({
+        set((state) => ({
           formConfigRef,
+          form: {
+            ...state.form,
+            id: formConfigRef.current?.id ?? state.form.id,
+          },
         }));
         get().actions.reset({ exclude: ["resetKey"] });
       },


### PR DESCRIPTION
The form id returned by useForm and useFormContext was not the right one we update it on the useForm config 